### PR TITLE
refactor: use the current ovos-config class names

### DIFF
--- a/ovos_media_plugin_chromecast/autoconfigure.py
+++ b/ovos_media_plugin_chromecast/autoconfigure.py
@@ -1,7 +1,7 @@
 from pprint import pprint
 
 import pychromecast
-from ovos_config.config import MycroftUserConfig
+from ovos_config.config import UserConfig
 
 
 def main():
@@ -13,7 +13,7 @@ def main():
     for cast in casts:
         print(f"    - Found Chromecast: {cast.cast_info.friendly_name} - {cast.cast_info.host}:{cast.cast_info.port}")
 
-    cfg = MycroftUserConfig()
+    cfg = UserConfig()
 
     devices = [cast.cast_info.friendly_name for cast in casts]
     if not devices:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
 ]
 keywords = ["ovos", "audio", "video", "OCP", "plugin"]
 dependencies = [
+    "ovos-config>=2.4.0a1,<3.0.0",
     "ovos-plugin-manager>=2.1.0,<3.0.0",
     "pychromecast",
     "zeroconf"


### PR DESCRIPTION
## Summary
- `ovos-config` PR #194 renames the config model classes, keeping the old names as deprecated subclass aliases. Migrates `MycroftUserConfig` -> `UserConfig` in `autoconfigure.py`.
- Raises the `ovos-config` dependency floor to `>=2.4.0a1,<3.0.0` and adds it as a **direct** dependency (it was previously only a transitive import, not declared).

## Notes
- ovos-config PR #194 is not yet merged/released. The `2.4.0a1` floor is a prediction based on `dev` currently at `2.3.4a1` and #194 being a `feat:`. **If #194 ships under a different version, this floor must be corrected before merge.**
- This PR must merge **after** #194 is merged and released to PyPI, not before.
- Per project policy the eventual removal of the deprecated aliases is a separate two-releases-out `chore!:` change; this PR only migrates the call site now so that removal is a no-op here.

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q` run before and after the change: same result both times (1 pre-existing unrelated failure in `test/test_backends.py::TestEntryPoints::test_setup_declares_new_and_legacy_groups`, 9 passed, 2 skipped). No new failures introduced by this change.
- [ ] CI (will pick up pre-#194 ovos-config from PyPI, so the new class name will not resolve until #194 is released — expected until then).